### PR TITLE
edit EXEC key of desktop file to point to wrapper script

### DIFF
--- a/com.seventhstring.Transcribe.metainfo.xml
+++ b/com.seventhstring.Transcribe.metainfo.xml
@@ -17,6 +17,9 @@
    </screenshots>
    <content_rating type="oars-1.0" />
    <releases>
+      <release version="9.10.0-3" date="2021-12-31">
+         <description>fixed broken .desktop file</description>
+      </release>
       <release version="9.10.0-2" date="2021-12-30">
          <description>fixed missing arguments in wrapper script</description>
       </release>

--- a/com.seventhstring.Transcribe.yml
+++ b/com.seventhstring.Transcribe.yml
@@ -40,6 +40,8 @@ modules:
   - type: archive
     url: https://www.seventhstring.com/xscribe/downlo/xscsetup-9.10.0.tar.gz
     sha256: 1eb061356c02b0c11e600519d793abb33c9af4c01d3efcd6b8c95fb5a015e58b
+  post-install:
+  - desktop-file-edit --set-key="Exec" --set-value="/app/bin/transcribe-wrapper %f" "/app/share/applications/seventhstring-transcribe.desktop"
   modules:
   - name: xdg-utils
     buildsystem: autotools


### PR DESCRIPTION
This PR fixes the broken .desktop file of the previous version by using `desktop-file-edit` to edit the EXEC key to point to the wrapper script again.