### PR TITLE
bump to version 9.20

### DIFF
--- a/com.seventhstring.Transcribe.metainfo.xml
+++ b/com.seventhstring.Transcribe.metainfo.xml
@@ -17,6 +17,9 @@
    </screenshots>
    <content_rating type="oars-1.0" />
    <releases>
+      <release version="9.20.0-1" date="2022-04-02">
+         <description>bump to version 9.20.0</description>
+      </release>
       <release version="9.10.0-3" date="2021-12-31">
          <description>fixed broken .desktop file</description>
       </release>

--- a/com.seventhstring.Transcribe.yml
+++ b/com.seventhstring.Transcribe.yml
@@ -38,10 +38,14 @@ modules:
       XDG_DATA_HOME: /app/share
   sources:
   - type: archive
-    url: https://www.seventhstring.com/xscribe/downlo/xscsetup-9.10.0.tar.gz
-    sha256: 1eb061356c02b0c11e600519d793abb33c9af4c01d3efcd6b8c95fb5a015e58b
+    url: https://www.seventhstring.com/xscribe/downlo/xscsetup-9.20.0.tar.gz
+    sha256: 95e5c0d4cfa934890b2ec1e54b8614b5e8027719aaeb8e4c970c36c0ffe9c1d8
   post-install:
-  - desktop-file-edit --set-key="Exec" --set-value="/app/bin/transcribe-wrapper %f" "/app/share/applications/seventhstring-transcribe.desktop"
+  - |
+      desktop-file-edit \
+        --set-key="Categories" --set-value="AudioVideo" \
+        --set-key="Exec" --set-value="/app/bin/transcribe-wrapper %f" \
+        "/app/share/applications/seventhstring-transcribe.desktop"
   modules:
   - name: xdg-utils
     buildsystem: autotools


### PR DESCRIPTION
This PR bumps transcribe to the newly released version [9.20](https://www.seventhstring.com/xscribe/downlo/xscsetup-9.20.0.tar.gz)

fixes #5 